### PR TITLE
10万件くらいまでは1秒くらいで終わるような shellscript に修正

### DIFF
--- a/innodb-deadlock-thread-id.md
+++ b/innodb-deadlock-thread-id.md
@@ -37,9 +37,7 @@ CREATE TABLE t1 (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC;
 EOF
 
-for i in $(seq 1 1000); do
-  echo "INSERT INTO t1 (number) VALUES ($i);"
-done | mysql test
+{ echo -n "INSERT INTO t1 (number) VALUES "; echo -n \({1..1000}\) | tr ' ' ','; } | mysql test
 ```
 
 対象テーブルの行数が少なすぎるとオプティマイザがフルスキャン判断をする場合があるので、行数を多めに用意する。


### PR DESCRIPTION
1 行ずつ INSERT だと件数が増えると遅いので、10 万行くらいまでは1秒くらいで終わるように修正しました。
以下、実行速度の比較です。

## 修正前

```console
# 10,000 行
$ time bash /tmp/init_db.sh
bash /tmp/init_db.sh  0.22s user 0.10s system 13% cpu 2.333 total
# 100,000 行
$ time bash /tmp/init_db.sh
bash /tmp/init_db.sh  2.03s user 0.97s system 13% cpu 21.519 total
```

## 修正後

```console
# 10,000 行
$ time bash /tmp/init_db.sh
bash /tmp/init_db.sh  0.05s user 0.01s system 46% cpu 0.146 total
# 100,000 行
$ time bash /tmp/init_db.sh
bash /tmp/init_db.sh  0.37s user 0.03s system 53% cpu 0.755 total
```